### PR TITLE
Create category pages as ?category=value

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ github_username: peterdesmet
 logo: assets/img/petri-dish_1f9eb.png # Navbar logo, will be displayed with 30px height
 posts_on_home: 3 # Number of posts to include on homepage, can be 0
 tweets_on_home: true
+archive_permalink: /blog/ # Permalink of page using archive.html layout, required when using categories
 colors:
   links: "#007bff"  # Color for links: use a readable color that contrasts well with dark text
   banner: "#007bff" # Background color for the banner when no background image is used

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card" data-categories="{{ post.categories | join: '|' }}">
   <a href="{{ post.url | relative_url }}">
     {% if post.background %}
       <img class="card-img-top" src="{{ post.background | relative_url }}">
@@ -23,10 +23,10 @@
     </div>
   </div>
 
-  {% if post.categories %}
+  {% if post.categories and site.archive_permalink %}
     <div class="card-footer">
       {% for category in post.categories %}
-        <span class="badge badge-pill">{{ category }}</span>
+        <a class="badge badge-pill" href="{{ site.archive_permalink | relative_url }}?category={{ category | url_encode }}">{{ category }}</a>
       {% endfor %}
     </div>
   {% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -71,3 +71,27 @@
 <script src="{{ '/assets/theme/js/jquery.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/theme/js/popper.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/theme/js/bootstrap.min.js' | relative_url }}"></script>
+
+{% if page.layout == 'archive' %}
+<script>
+  // Filter cards on ?category=value
+  $(document).ready(function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    
+    if (urlParams.has("category") && urlParams.get("category") != "") {
+      // Get category param: will decode param value + return 1st value in case of multiple category params
+      const category = urlParams.get("category");
+      
+      $(".card").each(function() {
+        const cardCategories = $(this).data("categories").split("|");
+        // Hide card if it does not contain the selected category
+        if (!cardCategories.includes(category)) {
+          $(this).parent().addClass("d-none");
+        }
+      });
+
+      $(".jumbotron .categories").append("<span class=\"badge badge-pill\">" + category + "</span>");
+    }
+  });
+</script>
+{% endif %}

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -8,19 +8,17 @@
         <div class="col-md-10 col-lg-8 mx-auto">
           <h1{% if page.layout == 'home' %} class="home"{% endif %}>{{ page.title }}</h1>
           
-          {% if page.description %}
-            <div class="lead">{{ page.description | markdownify }}</div>
-          {% endif %}
+          <div class="lead">{{ page.description | markdownify }}</div>
           
           <time>{{ page.date | date: "%B %d, %Y" }}</time>
 
-          {% if page.categories %}
-            <div class="mt-2">
+          <div class="categories">
+            {% if page.categories and site. archive_permalink %}
               {% for category in page.categories %}
-              <span class="badge badge-pill">{{ category }}</span>
+              <a class="badge badge-pill" href="{{ site.archive_permalink | relative_url }}?category={{ category | url_encode }}">{{ category }}</a>
               {% endfor %}
-            </div>
-          {% endif %}
+            {% endif %}
+          </div>
         </div>
       </div>
     </div>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -1,6 +1,7 @@
 ---
 layout: base
 description: Template for a list of posts, with full width
+remarks: See also page.layout == 'archive' in footer.html
 ---
 
 <div class="row">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,7 +1,7 @@
 ---
 layout: base
 description: Template for homepage
-remark: See also page.layout == 'home' in jumbotron.html and head.html
+remark: See also page.layout == 'home' in head.html and jumbotron.html
 ---
 
 <div class="row">

--- a/_posts/2019-05-18-welcome-to-jekyll.md
+++ b/_posts/2019-05-18-welcome-to-jekyll.md
@@ -1,7 +1,7 @@
 ---
 title: Welcome to Jekyll
 date: 2019-05-18 17:27:15 +0200
-categories: [Tutorials]
+categories: [Shared category, 👩‍🔬 Emoji category, "Special /?{:å characters"]
 ---
 
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.

--- a/_posts/2019-06-21-kickoff-meeting.md
+++ b/_posts/2019-06-21-kickoff-meeting.md
@@ -2,7 +2,7 @@
 title: Kickoff meeting
 description: 9-10 September 2019 in Ghent, Belgium
 background: "https://images.unsplash.com/photo-1558441440-d4111d18d48f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9?auto=format&fit=crop&w=1200&q=80"
-categories: [Meetings, Tutorials]
+categories: [Meetings, Shared category]
 ---
 
 This post has a portrait background image to test if it still renders nicely.

--- a/_sass/_card.scss
+++ b/_sass/_card.scss
@@ -4,8 +4,8 @@
   // Mimics Bootstrap .card-deck, stretching cards to equal height, but without
   // stretching width when there are fewer cards on one row (cards remain equal width)
   div[class*="col"] {
-    display: flex!important;
-    align-items: stretch!important; 
+    display: flex;
+    align-items: stretch;
   }
 }
 
@@ -32,9 +32,14 @@
 
     // Smaller badge then the one defined in _jumbotron.scss
     .badge {
-      border: 1px solid $body-color;
+      border: 1px solid $link-color;
       font-family: $font-family-base;
       text-transform: uppercase;
+
+      &:hover,
+      &:focus {
+        border: 1px solid $link-hover-color;
+      }
     }
   }
 }

--- a/_sass/_jumbotron.scss
+++ b/_sass/_jumbotron.scss
@@ -42,6 +42,7 @@
     border: 2px solid $white;
     padding-right: $badge-pill-padding-x * 2;
     padding-left: $badge-pill-padding-x * 2;
+    margin-top: 0.25rem;
     text-transform: uppercase;
   }
   


### PR DESCRIPTION
Categories are added as data-categories on `.card`. When there is a URL querystring with `?category=value`, then `.card`s (or rather their parent `.col`) are hidden when they don't contain the selected category. The select category is also shown in the jumbotron as a badge.

- Add new config parameter `archive_permalink`: **required** for categories to show up
- Add JS to footer (needed to be loaded after jQuery)
- Reimplement css for category badges (partly revert bbd9bb4c4a32fe1052e3c2259995a9ceb76f84ff)
- Don't use `!important` on card cols, because needs to work with `d-none`
- Add some margin around category badge
- Use test categories on posts
- Don't use if statements in jumbotron, but leave elements empty (they don't take up space)