### PR TITLE
Use tags, not categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Changes requiring review (e.g. new blog posts) should be created in a separate b
 - Use `72dpi` as image resolution
 - Place background images in `assets/backgrounds/`, name them after their corresponding page/post and ideally crop them to `2100 x 700px`
 - Place content images in `assets/images/`, name them after their corresponding page/post + a suffix, e.g. `-figure-1`
-- Add categories to posts to create relevant groups (e.g. same topic, project).
+- Add tags to posts to create relevant groups (e.g. same topic, project).
 - Create internal links as `[previous post]({{ '/permalink/to/post/' | relative_url }})`
 
 ## Repo structure

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ github_username: peterdesmet            # Can also be a repository: username/rep
 # THEME SETTINGS (ALL OPTIONAL)
 posts_on_home: 3                        # Show x number of latest posts on homepage, can be 0
 tweets_on_home: true                    # Show Twitter feed of twitter_username on homepage
-archive_permalink: /blog/               # Permalink of page using the archive.html layout, required when using post categories
+archive_permalink: /blog/               # Permalink of page using the archive.html layout, required when using post tags
 github_edit: true                       # Show an "edit this page" link in the footer
 colors:
   links: "#007bff"                      # Color for links: use a readable color that contrasts well with dark text

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -4,7 +4,7 @@
   {% assign background = item.background %}
 {% endif %}
 
-<div class="card" data-categories="{% for category in item.categories %}{{ category | downcase | strip }}|{% endfor %}">
+<div class="card" data-tags="{% for tag in item.tags %}{{ tag | downcase | strip }}|{% endfor %}">
   <a href="{{ item.url | relative_url }}">
     {% if item.background %}
       <img class="card-img-top" src="{{ background | relative_url }}">  
@@ -31,10 +31,10 @@
     </div>
   </div>
 
-  {% if item.collection == 'posts' and item.categories and site.archive_permalink %}
+  {% if item.collection == 'posts' and item.tags and site.archive_permalink %}
     <div class="card-footer">
-      {% for category in item.categories %}
-        <a class="badge{% if site.rounded_corners != false %} rounded-pill{% endif %}" href="{{ site.archive_permalink | relative_url }}?category={{ category | url_encode }}">{{ category }}</a>
+      {% for tag in item.tags %}
+        <a class="badge{% if site.rounded_corners != false %} rounded-pill{% endif %}" href="{{ site.archive_permalink | relative_url }}?tag={{ tag | url_encode }}">{{ tag }}</a>
       {% endfor %}
     </div>
   {% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,10 +20,10 @@
             </p>
           {% endif %}
 
-          <div class="categories">
-            {% if page.collection == 'posts' and page.categories and site.archive_permalink %}
-              {% for category in page.categories %}
-              <a class="badge{% if site.rounded_corners != false %} rounded-pill{% endif %}" href="{{ site.archive_permalink | relative_url }}?category={{ category | url_encode }}">{{ category }}</a>
+          <div class="tags">
+            {% if page.collection == 'posts' and page.tags and site.archive_permalink %}
+              {% for tag in page.tags %}
+              <a class="badge{% if site.rounded_corners != false %} rounded-pill{% endif %}" href="{{ site.archive_permalink | relative_url }}?tag={{ tag | url_encode }}">{{ tag }}</a>
               {% endfor %}
             {% endif %}
           </div>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -20,25 +20,25 @@ description: Template for a list of posts as cards, with full width.
 </div>
 
 <script>
-  // Filter cards on ?category=value
+  // Filter cards on ?tag=value
   $(document).ready(function() {
     const urlParams = new URLSearchParams(window.location.search);
     
-    if (urlParams.has("category") && urlParams.get("category") != "") {
-      const category = urlParams.get("category"); // Will return 1st category value + decode URI
-      const cleanCategory = $.trim(category.toLowerCase()); // Create category as written in .card data-categories
+    if (urlParams.has("tag") && urlParams.get("tag") != "") {
+      const tag = urlParams.get("tag"); // Will return 1st tag value + decode URI
+      const cleanTag = $.trim(tag.toLowerCase()); // Create tag as written in .card data-tags
       
       $(".card").each(function() {
-        const cardCategories = $(this).data("categories").split("|");
-        // Hide card if it does not contain the selected category
-        if (!cardCategories.includes(cleanCategory)) {
+        const cardTags = $(this).data("tags").split("|");
+        // Hide card if it does not contain the selected tag
+        if (!cardTags.includes(cleanTag)) {
           $(this).parent().addClass("d-none");
         }
       });
 
-      $(".header .categories").append(
+      $(".header .tags").append(
         '<a class="badge{% if site.rounded_corners != false %} rounded-pill{% endif %}" href="{{ site.archive_permalink | relative_url }}">' + 
-        category + '<span class="btn-close btn-close-white"></span>' + 
+        tag + '<span class="btn-close btn-close-white"></span>' + 
         '</a>'
       );
     }

--- a/_posts/2019-05-18-welcome-to-jekyll.md
+++ b/_posts/2019-05-18-welcome-to-jekyll.md
@@ -1,7 +1,7 @@
 ---
 title: Welcome to Jekyll
 date: 2019-05-18 17:27:15 +0200
-categories: [Shared category, 👩‍🔬 Emoji category, "Special /?{:å characters", " Whitespace before and after "]
+tags: [Shared tag, 👩‍🔬 Emoji tag, "Special /?{:å characters", " Whitespace before and after "]
 ---
 
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.

--- a/_posts/2019-06-21-kickoff-meeting.md
+++ b/_posts/2019-06-21-kickoff-meeting.md
@@ -6,7 +6,7 @@ background:
   by: Kyle Arcilla
   href: https://unsplash.com/photos/XA1pHcB5AMA
 author: [Philip J. Fry, Turanga Leela]
-categories: [Meetings, Shared category]
+tags: [Meetings, Shared tag]
 ---
 
 This post has a portrait background image to test if it still renders nicely.

--- a/_posts/2019-07-08-dmp.md
+++ b/_posts/2019-07-08-dmp.md
@@ -10,7 +10,7 @@ description: |
   [Light button](#){: .btn .btn-sm .btn-light}
 background: "https://images.unsplash.com/photo-1495841020177-1919ede29bd8?ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
 author: Philip J. Fry
-categories: [Data, Shared category]
+tags: [Data, Shared tag]
 comments: true
 ---
 

--- a/pages/docs/configuration.md
+++ b/pages/docs/configuration.md
@@ -139,10 +139,10 @@ To create an [overview page]({{ '/blog/' | relative_url }}) (source [`archive.md
 layout: archive
 ```
 
-And enable post categories by repeating the permalink for your archive page in  `_config.yml`:
+And enable post tags by repeating the permalink for your archive page in  `_config.yml`:
 
 ```yml
-archive_permalink: /blog/               # Permalink of page using the archive.html layout, required when using post categories
+archive_permalink: /blog/               # Permalink of page using the archive.html layout, required when using post tags
 ```
 
 To see blog posts, you'll have to create some. ☺️
@@ -159,7 +159,7 @@ title: "Title for the post: wrap in quotes if it contains special characters"
 description: Description that will appear below the title in the banner
 background: /assets/images/banner_background_image.jpg
 author: [Author 1, Author 2]
-categories: [Category 1, Category 2]
+tags: [Tag 1, Tag 2]
 toc: false # See pages
 comments: false
 published: true

--- a/pages/docs/installation.md
+++ b/pages/docs/installation.md
@@ -7,7 +7,7 @@ background:
   href: https://unsplash.com/photos/EysCLgycVgc
 permalink: /docs/installation/
 toc: true
-# categories: [categories are reserved for posts so this one will not show up]
+# tags: [tags are reserved for posts so this one will not show up]
 ---
 
 ## Create a site from scratch (recommended)


### PR DESCRIPTION
I initially opted for post categories, because that made most sense for the jekyll-archive plugin. That plugin is not supported on GitHub pages, so I implemented categories as a filter for posts (see e.g. http://peterdesmet.com/petridish/blog/?category=Shared+category).

However, that is conceptually more a [tag than a category](https://jekyllrb.com/docs/posts/#tags-and-categories) in my opinion:

- The order does not matter (in categories, those result in differently stacked subdirectories when using default permalinks)
- It does not conflict with how posts are organized in directories (e.g. `horror/_posts/` would automatically add the `horror` category, but not a `horror` tag).

So even though this is a breaking change, I'd prefer to use the one that conceptually makes the most sense. It also frees up categories to be used differently.